### PR TITLE
lib_check.py: Fix library checks when using python3.

### DIFF
--- a/lib_check.py
+++ b/lib_check.py
@@ -44,6 +44,7 @@ def main(args):
     # check MPI
     try:
         ver = subprocess.check_output( "conda list pydusa", shell=True, stderr=subprocess.STDOUT )
+        ver = str(ver.decode('utf-8'))
         ver = [ entry for entry in ver.split("\n") if not "#" in entry and entry != "" ][0]
         ver = " ".join(ver.split())
     
@@ -64,6 +65,7 @@ def main(args):
     # check CUDA installation
     try:
         ver = subprocess.check_output( "nvcc --version", shell=True, stderr=subprocess.STDOUT )
+        ver = str(ver.decode('utf-8'))
         ver = [ entry for entry in ver.split("\n") if entry != "" ]
     
     except subprocess.CalledProcessError as err:


### PR DESCRIPTION
This PR fixes [issue #8](https://github.com/phonchi/Cryo-RAlib/issues/8).

When using EMAN 2.91 with python3 the installation script will fail in the library checking step. This is because in Python 2 the bytes returned by `check_output` work similar to strings. In Python 3 this is not the case. This can be fixed by decoding the bytes into unicode strings and then changing them back into strings.